### PR TITLE
Add basic FastAPI and Node.js backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
+# Athena Cyber Watchtower
 
+This project provides a React/TypeScript frontend for a cybersecurity risk dashboard. To complement the UI, two example backends are included:
+
+- **FastAPI** (Python)
+- **Express** (Node.js)
+
+Each backend exposes similar endpoints used by the frontend (`/login`, `/dashboard`, `/vendors`). These implementations return mocked data and should be replaced with real integrations in production.
+
+## Running the FastAPI backend
+
+```bash
+cd backend/fastapi
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Running the Node.js backend
+
+```bash
+cd backend/node
+npm install
+npm start
+```
+
+Both servers will start on port `8000` (FastAPI default) or `3000` (Node.js default). Adjust the frontend configuration to point to the desired backend URL.

--- a/backend/fastapi/main.py
+++ b/backend/fastapi/main.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+@app.post("/login")
+def login(req: LoginRequest):
+    if req.username == "admin" and req.password == "password":
+        return {"token": "fake-jwt-token"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")
+
+@app.get("/dashboard")
+def dashboard():
+    return {
+        "riskTrendData": [
+            {"date": "2023-01-01", "riskScore": 80},
+            {"date": "2023-02-01", "riskScore": 70},
+        ]
+    }
+
+vendor_data = [
+    {"id": 1, "name": "Vendor A", "risk": 75},
+    {"id": 2, "name": "Vendor B", "risk": 60},
+]
+
+@app.get("/vendors")
+def get_vendors():
+    return vendor_data

--- a/backend/fastapi/requirements.txt
+++ b/backend/fastapi/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/backend/node/index.js
+++ b/backend/node/index.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  if (username === 'admin' && password === 'password') {
+    res.json({ token: 'fake-jwt-token' });
+  } else {
+    res.status(401).json({ message: 'Invalid credentials' });
+  }
+});
+
+app.get('/dashboard', (req, res) => {
+  res.json({
+    riskTrendData: [
+      { date: '2023-01-01', riskScore: 80 },
+      { date: '2023-02-01', riskScore: 70 }
+    ]
+  });
+});
+
+const vendors = [
+  { id: 1, name: 'Vendor A', risk: 75 },
+  { id: 2, name: 'Vendor B', risk: 60 }
+];
+
+app.get('/vendors', (req, res) => {
+  res.json(vendors);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/backend/node/package.json
+++ b/backend/node/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "watchtower-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add example FastAPI backend with login, dashboard and vendors endpoints
- add example Node.js (Express) backend with similar endpoints
- update README with instructions for running both servers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846ad3a8b148323a9ab18f4c38d2492